### PR TITLE
Add config options for time representation

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,12 +11,14 @@ import (
 )
 
 var DefaultOptions = Options{
-	LogLevel:       "info",
-	LevelFieldName: "level",
-	JSON:           false,
-	Concise:        false,
-	Tags:           nil,
-	SkipHeaders:    nil,
+	LogLevel:        "info",
+	LevelFieldName:  "level",
+	JSON:            false,
+	Concise:         false,
+	Tags:            nil,
+	SkipHeaders:     nil,
+	TimeFieldFormat: time.RFC3339Nano,
+	TimeFieldName:   "timestamp",
 }
 
 type Options struct {
@@ -48,6 +50,14 @@ type Options struct {
 
 	// SkipHeaders are additional headers which are redacted from the logs
 	SkipHeaders []string
+
+	// TimeFieldFormat defines the time format of the Time field, defaulting to "time.RFC3339Nano" see options at:
+	// https://pkg.go.dev/time#pkg-constants
+	TimeFieldFormat string
+
+	// TimeFieldName sets the field name for the time field.
+	// Some providers parse and search for different field names.
+	TimeFieldName string
 }
 
 // Configure will set new global/default options for the httplog and behaviour
@@ -59,6 +69,14 @@ func Configure(opts Options) {
 
 	if opts.LevelFieldName == "" {
 		opts.LevelFieldName = "level"
+	}
+
+	if opts.TimeFieldFormat == "" {
+		opts.TimeFieldFormat = time.RFC3339Nano
+	}
+
+	if opts.TimeFieldName == "" {
+		opts.TimeFieldName = "timestamp"
 	}
 
 	// Pre-downcase all SkipHeaders
@@ -77,10 +95,10 @@ func Configure(opts Options) {
 	zerolog.SetGlobalLevel(logLevel)
 
 	zerolog.LevelFieldName = strings.ToLower(opts.LevelFieldName)
-	zerolog.TimestampFieldName = "timestamp"
-	zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.TimestampFieldName = strings.ToLower(opts.TimeFieldName)
+	zerolog.TimeFieldFormat = opts.TimeFieldFormat
 
 	if !opts.JSON {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: opts.LevelFieldName})
 	}
 }


### PR DESCRIPTION
To better fit Google Cloud Platform (e.g. when running your Go project on Cloud Run as was my case), I added 2 additional Options:

- TimeFieldFormat, to define the time format
- TimeFieldName, to set the field name in which the time is placed

## Motivation
This allows to config how time is outputted and into what field, as [Google Cloud Logging requires](https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing) to have a `time` field with an [RFC 3339](https://tools.ietf.org/html/rfc3339) formatted date in it, like so:

```plain
{
    "time": CURRENT_TIME_RFC3339
}
```

## Consequence
With this change you can start your logger like this:
```go
// Logger
logger := httplog.NewLogger("httplog-cloudrun-example", httplog.Options{
JSON:            true,
Concise:         true,
LevelFieldName:  "severity",
TimeFieldFormat: time.RFC3339,
TimeFieldName:   "time",
})
```
The GCP Logging agent can now strip the time field from jsonPayload and
collapse it into a single representation in the [timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp) field in the [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) object 🎉 