### PR TITLE
config: Fix timestamp when JSON logging is disabled

### DIFF
--- a/config.go
+++ b/config.go
@@ -99,6 +99,6 @@ func Configure(opts Options) {
 	zerolog.TimeFieldFormat = opts.TimeFieldFormat
 
 	if !opts.JSON {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: opts.LevelFieldName})
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: opts.TimeFieldFormat})
 	}
 }


### PR DESCRIPTION
Hi,

I noticed the timestamp is not present in the logger when JSON logging is disabled. I noticed that during configuration the wrong field is used to configure the timestamp format. This PR fixes that issue. Also confirmed by testing it.

Old format:
```
level INF Request: GET ...
```

New format:
```
2022-05-06T11:04:44+02:00 INF Request: GET ...
```