### PR TITLE
fixes stacktrace logging

### DIFF
--- a/httplog.go
+++ b/httplog.go
@@ -55,7 +55,7 @@ func RequestLogger(logger *Logger, skipPaths ...[]string) func(next http.Handler
 }
 
 func Handler(logger *Logger, optSkipPaths ...[]string) func(next http.Handler) http.Handler {
-	var f middleware.LogFormatter = &requestLogger{*logger.Logger, logger.Options}
+	var f middleware.LogFormatter = &requestLogger{logger.Logger, logger.Options}
 
 	skipPaths := map[string]struct{}{}
 	if len(optSkipPaths) > 0 {
@@ -102,18 +102,18 @@ func Handler(logger *Logger, optSkipPaths ...[]string) func(next http.Handler) h
 }
 
 type requestLogger struct {
-	Logger  slog.Logger
+	Logger  *slog.Logger
 	Options Options
 }
 
 func (l *requestLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &RequestLoggerEntry{}
+	entry := &RequestLoggerEntry{l.Logger, l.Options, ""}
 	msg := fmt.Sprintf("Request: %s %s", r.Method, r.URL.Path)
 
 	if l.Options.RequestHeaders {
-		entry.Logger = *l.Logger.With(requestLogFields(r, l.Options, true))
+		entry.Logger = l.Logger.With(requestLogFields(r, l.Options, true))
 	} else {
-		entry.Logger = *l.Logger.With(requestLogFields(r, l.Options, false))
+		entry.Logger = l.Logger.With(requestLogFields(r, l.Options, false))
 	}
 
 	if !l.Options.Concise {
@@ -123,7 +123,7 @@ func (l *requestLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 }
 
 type RequestLoggerEntry struct {
-	Logger  slog.Logger
+	Logger  *slog.Logger
 	Options Options
 	msg     string
 }
@@ -160,7 +160,7 @@ func (l *RequestLoggerEntry) Panic(v interface{}, stack []byte) {
 	if l.Options.JSON {
 		stacktrace = string(stack)
 	}
-	l.Logger = *l.Logger.With(
+	l.Logger = l.Logger.With(
 		slog.Attr{
 			Key:   "stacktrace",
 			Value: slog.StringValue(stacktrace)},
@@ -328,7 +328,7 @@ func ErrAttr(err error) slog.Attr {
 // passes through the handler chain, which at any point can be logged
 // with a call to .Print(), .Info(), etc.
 
-func LogEntry(ctx context.Context) slog.Logger {
+func LogEntry(ctx context.Context) *slog.Logger {
 	entry, ok := ctx.Value(middleware.LogEntryCtxKey).(*RequestLoggerEntry)
 	if !ok || entry == nil {
 		handlerOpts := &slog.HandlerOptions{
@@ -338,7 +338,7 @@ func LogEntry(ctx context.Context) slog.Logger {
 			Level: slog.LevelError + 1,
 			// ReplaceAttr: func(attr slog.Attr) slog.Attr ,
 		}
-		return *slog.New(slog.NewTextHandler(os.Stdout, handlerOpts))
+		return slog.New(slog.NewTextHandler(os.Stdout, handlerOpts))
 	} else {
 		return entry.Logger
 	}
@@ -346,7 +346,7 @@ func LogEntry(ctx context.Context) slog.Logger {
 
 func LogEntrySetField(ctx context.Context, key string, value slog.Value) {
 	if entry, ok := ctx.Value(middleware.LogEntryCtxKey).(*RequestLoggerEntry); ok {
-		entry.Logger = *entry.Logger.With(slog.Attr{Key: key, Value: value})
+		entry.Logger = entry.Logger.With(slog.Attr{Key: key, Value: value})
 	}
 }
 
@@ -358,6 +358,6 @@ func LogEntrySetFields(ctx context.Context, fields map[string]interface{}) {
 			attrs[i] = slog.Attr{Key: k, Value: slog.AnyValue(v)}
 			i++
 		}
-		entry.Logger = *entry.Logger.With(attrs)
+		entry.Logger = entry.Logger.With(attrs)
 	}
 }


### PR DESCRIPTION
It seems to me that in structures a pointer to a slog.Logger will look more clear.
Fixed missing field initialization.