### PR TITLE
neutral color for timestamp

### DIFF
--- a/text_handler.go
+++ b/text_handler.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"runtime"
 	"sync"
 	"time"
-
-	"log/slog"
 )
 
 type PrettyHandler struct {
@@ -65,7 +64,7 @@ func (h *PrettyHandler) Handle(ctx context.Context, r slog.Record) error {
 			timeAttr.Value = slog.StringValue(timeAttr.Value.Time().Format(time.RFC3339Nano))
 		}
 		// write time, level and source to buf
-		cW(buf, true, bBlack, "%s", timeAttr.Value.String())
+		cW(buf, false, bBlack, "%s", timeAttr.Value.String())
 		buf.WriteString(" ")
 	}
 


### PR DESCRIPTION
Timestamp text is set as black, then the timestamp is invisible in black terminal.
This PR just turns off coloring of timestamp.
Before:
![image](https://github.com/go-chi/httplog/assets/17728576/3fad80a0-3920-43e8-9d5a-50dffea16164)
After:
![image](https://github.com/go-chi/httplog/assets/17728576/75ca813d-abd1-4c0b-9a66-4031305257a2)

