### PR TITLE
Bugfix/log entry set fields

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -42,7 +42,16 @@ func main() {
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+
+			// Set a single log field
 			httplog.LogEntrySetField(ctx, "user", slog.StringValue("user1"))
+
+			// Set multiple fields
+			fields := map[string]any{
+				"remote": "example.com",
+				"action": "update",
+			}
+			httplog.LogEntrySetFields(ctx, fields)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	})

--- a/httplog.go
+++ b/httplog.go
@@ -352,12 +352,12 @@ func LogEntrySetField(ctx context.Context, key string, value slog.Value) {
 
 func LogEntrySetFields(ctx context.Context, fields map[string]interface{}) {
 	if entry, ok := ctx.Value(middleware.LogEntryCtxKey).(*RequestLoggerEntry); ok {
-		attrs := make([]slog.Attr, len(fields))
+		attrs := make([]any, len(fields))
 		i := 0
 		for k, v := range fields {
 			attrs[i] = slog.Attr{Key: k, Value: slog.AnyValue(v)}
 			i++
 		}
-		entry.Logger = entry.Logger.With(attrs)
+		entry.Logger = entry.Logger.With(attrs...)
 	}
 }

--- a/httplog_test.go
+++ b/httplog_test.go
@@ -47,7 +47,7 @@ func TestLogEntrySetFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			entry := &RequestLoggerEntry{
-				Logger: *slog.New(tt.args.handler),
+				Logger: slog.New(tt.args.handler),
 			}
 			req := middleware.WithLogEntry(httptest.NewRequest("GET", "/", nil), entry)
 			LogEntrySetFields(req.Context(), tt.args.fields)

--- a/httplog_test.go
+++ b/httplog_test.go
@@ -1,0 +1,89 @@
+package httplog
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func TestLogEntrySetFields(t *testing.T) {
+
+	type args struct {
+		handler *testHandler
+		fields  map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test_fields_set",
+			args: args{
+				handler: &testHandler{},
+				fields: map[string]interface{}{
+					"foo": 1000,
+					"bar": "account",
+				},
+			},
+		},
+		{
+			name: "test_empty",
+			args: args{
+				handler: &testHandler{},
+				fields:  make(map[string]interface{}),
+			},
+		},
+		{
+			name: "test_fields_nil",
+			args: args{
+				handler: &testHandler{},
+				fields:  nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := &RequestLoggerEntry{
+				Logger: *slog.New(tt.args.handler),
+			}
+			req := middleware.WithLogEntry(httptest.NewRequest("GET", "/", nil), entry)
+			LogEntrySetFields(req.Context(), tt.args.fields)
+
+			if len(tt.args.handler.attrs) != len(tt.args.fields) {
+				t.Fatalf("expected %v, got %v", len(tt.args.handler.attrs), len(tt.args.fields))
+			}
+			// Ensure all fields are present in the handler
+			for k, v := range tt.args.fields {
+				for i, attr := range tt.args.handler.attrs {
+					if attr.Key == k {
+						if !attr.Value.Equal(slog.AnyValue(v)) {
+							t.Fatalf("expected %v, got %v", attr.Value, v)
+						}
+						break
+					}
+					if i == len(tt.args.handler.attrs)-1 {
+						t.Fatalf("expected %v, got %v", k, attr.Key)
+					}
+				}
+			}
+		})
+	}
+}
+
+type testHandler struct {
+	attrs []slog.Attr
+}
+
+func (*testHandler) Enabled(_ context.Context, l slog.Level) bool { return true }
+
+func (h *testHandler) Handle(ctx context.Context, r slog.Record) error { return nil }
+
+func (h *testHandler) WithAttrs(as []slog.Attr) slog.Handler {
+	h.attrs = as
+	return h
+}
+
+func (h *testHandler) WithGroup(name string) slog.Handler { return h }


### PR DESCRIPTION
`LogEntrySetFields`: Use the varargs syntax to supply the additional log arguments correctly

Without the change in this changeset, running `go test` fails with:

```
./httplog.go:361:37: slog.Logger.With arg "attrs" should be a string or a slog.Attr (possible missing key or value)
FAIL
```

This is due to the fact that the array of `slog.Attr`s was supplied as
a single arg (i.e. a single slice of attributes) to
`*entry.Logger.With`, instead of a variable number of arguments.

Example:

```go
fields := map[string]any{
        "remote": "example.com",
        "action": "update",
}
httplog.LogEntrySetFields(ctx, fields)
```

Without this change, the updated example that uses LogEntrySetFields
creates the following log entry:

```
user: "user1" !BADKEY: [remote=example.com action=update]
```

With the change the log line for the updated example is:

```
user: "user1" remote: "example.com" action: "update"
```
