### PR TITLE
Ensure the httplog.Options from httplog.Logger are present in middleware.LogEntry

### DIFF
--- a/httplog.go
+++ b/httplog.go
@@ -107,7 +107,7 @@ type requestLogger struct {
 }
 
 func (l *requestLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &RequestLoggerEntry{}
+	entry := &RequestLoggerEntry{Options: l.Options}
 	msg := fmt.Sprintf("Request: %s %s", r.Method, r.URL.Path)
 
 	if l.Options.RequestHeaders {

--- a/httplog_test.go
+++ b/httplog_test.go
@@ -1,0 +1,46 @@
+package httplog
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Test that ensures the Logger options match the options of a LogEntry
+func Test_requestLogger_NewLogEntry_Options(t *testing.T) {
+	opts := Options{
+		Concise: true,
+		JSON:    true,
+	}
+	logger := &Logger{
+		Logger:  slog.Default(),
+		Options: opts,
+	}
+
+	r := chi.NewMux()
+	r.Use(Handler(logger))
+
+	var entryFromRequest middleware.LogEntry
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		entryFromRequest = middleware.GetLogEntry(r)
+		w.Write([]byte("OK"))
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	rEntry, ok := entryFromRequest.(*RequestLoggerEntry)
+	if !ok {
+		t.Errorf("expected log entry to be a RequestLoggerEntry")
+	}
+	if !reflect.DeepEqual(opts, rEntry.Options) {
+		t.Errorf("entry = %v, want %v", entryFromRequest, opts)
+	}
+}


### PR DESCRIPTION
This fixes #35 as the httplog.Options#JSON now causes the log entry to not be pretty printed to stderr if set to true.