### PR TITLE
Allow log level to be changed dynamically during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import (
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).With(
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LogInfo})).With(
 		slog.String("app", "example-app"),
 		slog.String("version", "v1.0.0-a1fa420"),
 		slog.String("env", "production"),
@@ -51,13 +51,6 @@ func main() {
 
 	// Request logger
 	r.Use(httplog.RequestLogger(logger, &httplog.Options{
-		// Level defines the verbosity of the request logs:
-		// slog.LevelDebug - log all responses (incl. OPTIONS)
-		// slog.LevelInfo  - log responses (excl. OPTIONS)
-		// slog.LevelWarn  - log 4xx and 5xx responses only (except for 429)
-		// slog.LevelError - log 5xx responses only
-		Level: slog.LevelInfo,
-
 		// Set log output to Elastic Common Schema (ECS) format.
 		Schema: httplog.SchemaECS,
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httplog/v3"
 	"github.com/go-chi/traceid"
 	"github.com/golang-cz/devslog"
-	"github.com/go-chi/httplog/v3"
 )
 
 func main() {
@@ -42,13 +42,6 @@ func main() {
 
 	// Request logger
 	r.Use(httplog.RequestLogger(logger, &httplog.Options{
-		// Level defines the verbosity of the request logs:
-		// slog.LevelDebug - log all responses (incl. OPTIONS)
-		// slog.LevelInfo  - log all responses (excl. OPTIONS)
-		// slog.LevelWarn  - log 4xx and 5xx responses only (except for 429)
-		// slog.LevelError - log 5xx responses only
-		Level: slog.LevelInfo,
-
 		// Use Elastic Common Schema (SchemaECS) log output format.
 		Schema: httplog.SchemaECS.Concise(isLocalhost),
 

--- a/middleware.go
+++ b/middleware.go
@@ -105,8 +105,8 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 					lvl = slog.LevelInfo
 				}
 
-				// Skip logging if the message level is below the logger's level or the minimum level specified in options
-				if !logger.Enabled(ctx, lvl) || lvl < o.Level {
+				// Skip logging if the message level is below the logger's level
+				if !logger.Enabled(ctx, lvl) {
 					return
 				}
 

--- a/options.go
+++ b/options.go
@@ -6,15 +6,6 @@ import (
 )
 
 type Options struct {
-	// Level defines the verbosity of the request logs:
-	// slog.LevelDebug - log both request starts & responses (incl. OPTIONS)
-	// slog.LevelInfo  - log responses (excl. OPTIONS)
-	// slog.LevelWarn  - log 4xx and 5xx responses only (except for 429)
-	// slog.LevelError - log 5xx responses only
-	//
-	// You can override the level with a custom slog.Handler, e.g. on per-request basis.
-	Level slog.Level
-
 	// Schema defines the mapping of semantic log fields to their corresponding
 	// field names in different logging systems and standards.
 	//
@@ -98,7 +89,6 @@ type Options struct {
 }
 
 var defaultOptions = Options{
-	Level:               slog.LevelInfo,
 	Schema:              SchemaECS,
 	RecoverPanics:       true,
 	LogRequestHeaders:   []string{"Content-Type", "Origin"},


### PR DESCRIPTION
Setting the log level as an option on the RequestLogger is redundant. The general pattern is that the source (RequestLogger) sets the level of each log, and the logger determines whether or not the log should be emitted, based on the logger's log level.