### PR TITLE
Rename "ClientDisconnected" error to "ClientAborted"

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,6 +5,10 @@ import (
 	"log/slog"
 )
 
+const (
+	ErrorKey = "error"
+)
+
 type ctxKeyLogAttrs struct{}
 
 func (c *ctxKeyLogAttrs) String() string {
@@ -29,7 +33,7 @@ func getAttrs(ctx context.Context) []slog.Attr {
 // SetError sets the error attribute on the request log.
 func SetError(ctx context.Context, err error) error {
 	if err != nil {
-		SetAttrs(ctx, slog.String("error.message", err.Error()))
+		SetAttrs(ctx, slog.Any(ErrorKey, err))
 	}
 
 	return err

--- a/middleware.go
+++ b/middleware.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	errClientAborted = fmt.Errorf("client disconnected before response was sent")
+	ErrClientAborted = fmt.Errorf("request aborted: client disconnected before response was sent")
 )
 
 func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Handler {
@@ -139,7 +139,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 				)
 
 				if err := ctx.Err(); errors.Is(err, context.Canceled) {
-					logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorMessage, errClientAborted.Error()), slog.String(s.ErrorType, "ClientAborted"))
+					logAttrs = appendAttrs(logAttrs, slog.Any(ErrorKey, ErrClientAborted), slog.String(s.ErrorType, "ClientAborted"))
 				}
 
 				if logReqBody || o.LogExtraAttrs != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrClientDisconnected = fmt.Errorf("client disconnected before response was sent")
+	errClientAborted = fmt.Errorf("client disconnected before response was sent")
 )
 
 func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Handler {
@@ -91,7 +91,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 				duration := time.Since(start)
 				statusCode := ww.Status()
 				if statusCode == 0 {
-					// If the handler never explicitly calls w.WriteHeader(statusCode),
+					// If the handler never calls w.WriteHeader(statusCode) explicitly,
 					// Go's http package automatically sends HTTP 200 OK to the client.
 					statusCode = 200
 				}
@@ -139,7 +139,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 				)
 
 				if err := ctx.Err(); errors.Is(err, context.Canceled) {
-					logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorMessage, ErrClientDisconnected.Error()), slog.String(s.ErrorType, "ClientDisconnected"))
+					logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorMessage, errClientAborted.Error()), slog.String(s.ErrorType, "ClientAborted"))
 				}
 
 				if logReqBody || o.LogExtraAttrs != nil {

--- a/options.go
+++ b/options.go
@@ -12,7 +12,7 @@ type Options struct {
 	// slog.LevelWarn  - log 4xx and 5xx responses only (except for 429)
 	// slog.LevelError - log 5xx responses only
 	//
-	// You can override the level with a custom slog.Handler, e.g. on per-request basis.
+	// You can override the level with a custom slog.Handler (e.g. on per-request basis).
 	Level slog.Level
 
 	// Schema defines the mapping of semantic log fields to their corresponding
@@ -25,7 +25,7 @@ type Options struct {
 	// httplog.SchemaOTEL (OpenTelemetry)
 	// httplog.SchemaGCP (Google Cloud Platform)
 	//
-	// Append .Concise(true) to reduce log verbosity, e.g. for localhost development.
+	// Append .Concise(true) to reduce log verbosity (e.g. for localhost development).
 	Schema *Schema
 
 	// RecoverPanics recovers from panics occurring in the underlying HTTP handlers

--- a/schema.go
+++ b/schema.go
@@ -190,7 +190,7 @@ func (s *Schema) ReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 
 		if s.SourceFile == "" {
 			// Ignore httplog.RequestLogger middleware source.
-			if strings.Contains(source.File, "go-chi/httplog") {
+			if strings.Contains(source.File, "/go-chi/httplog/") {
 				return slog.Attr{}
 			}
 			return a
@@ -199,17 +199,21 @@ func (s *Schema) ReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 		if s.GroupDelimiter == "" {
 			return slog.Group("", slog.String(s.SourceFile, source.File), slog.Int(s.SourceLine, source.Line), slog.String(s.SourceFunction, source.Function))
 		}
+
 		grp, file, _ := strings.Cut(s.SourceFile, s.GroupDelimiter)
 		_, line, _ := strings.Cut(s.SourceLine, s.GroupDelimiter)
 		_, fn, _ := strings.Cut(s.SourceFunction, s.GroupDelimiter)
 		return slog.Group(grp, slog.String(file, source.File), slog.Int(line, source.Line), slog.String(fn, source.Function))
+
+	case ErrorKey:
+		return slog.Attr{Key: s.ErrorMessage, Value: a.Value}
 	}
 
 	return a
 }
 
-// Concise returns a simplified schema with essential fields only. When concise is true,
-// it reduces log output by keeping only error, request, and response details.
+// Concise returns a simplified schema with essential fields only.
+// If concise is true, it reduces log verbosity.
 //
 // This is useful for localhost development to reduce log verbosity.
 func (s *Schema) Concise(concise bool) *Schema {
@@ -219,7 +223,6 @@ func (s *Schema) Concise(concise bool) *Schema {
 
 	return &Schema{
 		ErrorMessage:       s.ErrorMessage,
-		ErrorType:          s.ErrorType,
 		ErrorStackTrace:    s.ErrorStackTrace,
 		RequestHeaders:     s.RequestHeaders,
 		RequestBody:        s.RequestBody,

--- a/schema.go
+++ b/schema.go
@@ -14,10 +14,10 @@ import (
 type Schema struct {
 	// Base attributes for core logging information.
 	Timestamp       string // Timestamp of the log entry
-	Level           string // Log level (info, warn, error, etc.)
+	Level           string // Log level (e.g. INFO, WARNING, ERROR)
 	Message         string // Primary log message
 	ErrorMessage    string // Error message when an error occurs
-	ErrorType       string // Low-cardinality error type ("ClientDisconnected", "ValidationError", etc.)
+	ErrorType       string // Low-cardinality error type (e.g. "ClientAborted", "ValidationError")
 	ErrorStackTrace string // Stack trace for panic or error
 
 	// Source code location attributes for tracking origin of log statements.
@@ -28,12 +28,12 @@ type Schema struct {
 	// Request attributes for the incoming HTTP request.
 	// NOTE: RequestQuery is intentionally not supported as it would likely leak sensitive data.
 	RequestURL         string // Full request URL
-	RequestMethod      string // HTTP method (GET, POST, etc.)
+	RequestMethod      string // HTTP method (e.g. GET, POST)
 	RequestPath        string // URL path component
 	RequestRemoteIP    string // Client IP address
 	RequestHost        string // Host header value
 	RequestScheme      string // URL scheme (http, https)
-	RequestProto       string // HTTP protocol version (HTTP/1.1, HTTP/2, etc.)
+	RequestProto       string // HTTP protocol version (e.g. HTTP/1.1, HTTP/2)
 	RequestHeaders     string // Selected request headers
 	RequestBody        string // Request body content, if logged.
 	RequestBytes       string // Size of request body in bytes


### PR DESCRIPTION
Don't expose the error in pkg API, as we don't return it in the first place.
