### PR TITLE
feat: add `ResponseBytes` and `RequestBytesUnread` to LogAdditionalAttrsOptions.AdditionalAttrs

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -41,8 +41,19 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 			logReqBody := o.LogRequestBody != nil && o.LogRequestBody(r)
 			logRespBody := o.LogResponseBody != nil && o.LogResponseBody(r)
 
+			var includeAdditionalAttrsReqBody bool
+			if o.LogAdditionalAttrs != nil {
+				if o.LogAdditionalAttrs.AdditionalAttrs != nil && o.LogAdditionalAttrs.IncludeRequestBody != nil {
+					includeAdditionalAttrsReqBody = o.LogAdditionalAttrs.IncludeRequestBody(r)
+				}
+			} else if o.LogExtraAttrs != nil {
+				includeAdditionalAttrsReqBody = true
+			}
+			hasReqBody := r.Body != nil && r.Body != http.NoBody
+			consumeBody := hasReqBody && (logReqBody || includeAdditionalAttrsReqBody)
+
 			var reqBody bytes.Buffer
-			if logReqBody || o.LogExtraAttrs != nil {
+			if consumeBody {
 				r.Body = io.NopCloser(io.TeeReader(r.Body, &reqBody))
 			}
 
@@ -142,7 +153,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 					logAttrs = appendAttrs(logAttrs, slog.Any(ErrorKey, ErrClientAborted), slog.String(s.ErrorType, "ClientAborted"))
 				}
 
-				if logReqBody || o.LogExtraAttrs != nil {
+				if consumeBody {
 					// Ensure the request body is fully read if the underlying HTTP handler didn't do so.
 					n, _ := io.Copy(io.Discard, r.Body)
 					if n > 0 {
@@ -155,7 +166,15 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 				if logRespBody {
 					logAttrs = appendAttrs(logAttrs, slog.String(s.ResponseBody, logBody(&respBody, ww.Header(), o)))
 				}
-				if o.LogExtraAttrs != nil {
+				if o.LogAdditionalAttrs != nil {
+					if o.LogAdditionalAttrs.AdditionalAttrs != nil {
+						logAttrs = appendAttrs(logAttrs, o.LogAdditionalAttrs.AdditionalAttrs(&LogDetails{
+							Request:        r,
+							RequestBody:    reqBody.String(),
+							ResponseStatus: statusCode,
+						})...)
+					}
+				} else if o.LogExtraAttrs != nil {
 					logAttrs = appendAttrs(logAttrs, o.LogExtraAttrs(r, reqBody.String(), statusCode)...)
 				}
 				logAttrs = appendAttrs(logAttrs, getAttrs(ctx)...)

--- a/options.go
+++ b/options.go
@@ -144,6 +144,9 @@ type LogAdditionalAttrsOptions struct {
 type LogDetails struct {
 	Request *http.Request
 	// Contains the request body if either Options.LogRequestBody or LogAdditionalAttrsOptions.IncludeRequestBody is true, otherwise it is empty.
-	RequestBody    string
-	ResponseStatus int
+	RequestBody string
+	// Contains the number of unread bytes from the request body if either Options.LogRequestBody or LogAdditionalAttrsOptions.IncludeRequestBody is true, otherwise it is 0.
+	RequestBytesUnread int64
+	ResponseStatus     int
+	ResponseBytes      int
 }


### PR DESCRIPTION
> [!NOTE]
> This PR assumes #68 is merged.  If #68 is not merged, the signature to `LogExtraAttrs` would need to change to pass this information through.  PR #68 introduces a non-breaking change that allows adding additional information moving forward without requiring a breaking change.

Adds passing `ResponseBytes` and `RequestBytesUnread` to `LogAdditionalAttrsOptions.AdditionalAttrs`.

Note - A similar thing can/should be done for RequestBytesRead assuming PR #67 is merged.

Resolves #63