### PR TITLE
test: add TestCURL and fix LogResponseBody doc comment typo

### DIFF
--- a/curl_test.go
+++ b/curl_test.go
@@ -1,0 +1,34 @@
+package httplog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCURL(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+	req.Host = "example.com"
+	req.Header.Set("Authorization", "Bearer secret")
+	got := CURL(req, "")
+	expected := "curl 'http://example.com/api/v1/users' -H 'Authorization: Bearer secret'"
+	if got != expected {
+		t.Errorf("CURL(GET) = %q, want %q", got, expected)
+	}
+
+	postReq := httptest.NewRequest(http.MethodPost, "/api/v1/users", nil)
+	postReq.Host = "example.com"
+	postGot := CURL(postReq, `{"name":"alice"}`)
+	expectedPost := `curl 'http://example.com/api/v1/users' --data-raw '{"name":"alice"}'`
+	if postGot != expectedPost {
+		t.Errorf("CURL(POST) = %q, want %q", postGot, expectedPost)
+	}
+
+	putReq := httptest.NewRequest(http.MethodPut, "/api/v1/users/1", nil)
+	putReq.Host = "example.com"
+	putGot := CURL(putReq, "")
+	expectedPut := `curl -X PUT 'http://example.com/api/v1/users/1'`
+	if putGot != expectedPut {
+		t.Errorf("CURL(PUT) = %q, want %q", putGot, expectedPut)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// Options defines configuration options for the httplog middleware.
 type Options struct {
 	// Level defines the verbosity of the request logs:
 	// slog.LevelDebug - log both request starts & responses (incl. OPTIONS)
@@ -60,10 +61,10 @@ type Options struct {
 	// If not provided, there are no default headers.
 	LogResponseHeaders []string
 
-	// LogRequestBody is an optional predicate function that controls logging of request body.
+	// LogResponseBody is an optional predicate function that controls logging of response body.
 	//
-	// If the function returns true, the request body will be logged.
-	// If false, no request body will be logged.
+	// If the function returns true, the response body will be logged.
+	// If false, no response body will be logged.
 	//
 	// WARNING: Do not leak any response bodies with sensitive information.
 	LogResponseBody func(req *http.Request) bool


### PR DESCRIPTION
### Summary
- In `options.go`, fix copy-paste typo in `LogResponseBody` doc comment (`LogRequestBody` -> `LogResponseBody`, and `request body` -> `response body`).
- Add missing `Options` type doc comment in `options.go`.
- Add unit tests `TestCURL` in `curl_test.go` covering GET, POST (with payload), and PUT methods.