### PR TITLE
fix: align schema field names and values with ECS/OTEL/GCP specs

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -72,19 +72,10 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 					logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorMessage, fmt.Sprintf("panic: %v", rec)))
 
 					if rec != http.ErrAbortHandler {
-						pc := make([]uintptr, 10)   // Capture up to 10 stack frames.
-						n := runtime.Callers(3, pc) // Skip 3 frames (this middleware + runtime/panic.go).
-						pc = pc[:n]
-
-						// Process panic stack frames to print detailed information.
-						frames := runtime.CallersFrames(pc)
-						var stackValues []string
-						for frame, more := frames.Next(); more; frame, more = frames.Next() {
-							if !strings.Contains(frame.File, "runtime/panic.go") {
-								stackValues = append(stackValues, fmt.Sprintf("%s:%d", frame.File, frame.Line))
-							}
-						}
-						logAttrs = appendAttrs(logAttrs, slog.Any(s.ErrorStackTrace, stackValues))
+						// Go panic format: a single string parseable by GCP Error Reporting,
+						// matching the string type of ECS/OTEL stack trace fields.
+						stackTrace := fmt.Sprintf("panic: %v\n\n%s", rec, debug.Stack())
+						logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorStackTrace, stackTrace))
 					}
 				}
 

--- a/middleware.go
+++ b/middleware.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"runtime/debug"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -74,7 +74,10 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 					if rec != http.ErrAbortHandler {
 						// Go panic format: a single string parseable by GCP Error Reporting,
 						// matching the string type of ECS/OTEL stack trace fields.
-						stackTrace := fmt.Sprintf("panic: %v\n\n%s", rec, debug.Stack())
+						// Single fixed-buffer stack walk; debug.Stack() re-walks on every buffer grow.
+						buf := make([]byte, 16<<10)
+						n := runtime.Stack(buf, false)
+						stackTrace := fmt.Sprintf("panic: %v\n\n%s", rec, buf[:n])
 						logAttrs = appendAttrs(logAttrs, slog.String(s.ErrorStackTrace, stackTrace))
 					}
 				}

--- a/schema.go
+++ b/schema.go
@@ -65,107 +65,111 @@ var (
 	// SchemaECS represents the Elastic Common Schema (ECS) version 9.0.0.
 	// This schema is widely used with Elasticsearch and the Elastic Stack.
 	//
-	// Reference: https://www.elastic.co/guide/en/ecs/current/ecs-http.html
+	// Reference: https://www.elastic.co/docs/reference/ecs/ecs-field-reference
 	SchemaECS = &Schema{
-		Timestamp:          "@timestamp",
-		Level:              "log.level",
-		Message:            "message",
-		ErrorMessage:       "error.message",
-		ErrorType:          "error.type",
-		ErrorStackTrace:    "error.stack_trace",
-		SourceFile:         "log.origin.file.name",
-		SourceLine:         "log.origin.file.line",
-		SourceFunction:     "log.origin.function",
-		RequestURL:         "url.full",
-		RequestMethod:      "http.request.method",
-		RequestPath:        "url.path",
-		RequestRemoteIP:    "client.ip",
-		RequestHost:        "url.domain",
-		RequestScheme:      "url.scheme",
-		RequestProto:       "http.version",
-		RequestHeaders:     "http.request.headers",
-		RequestBody:        "http.request.body.content",
-		RequestBytes:       "http.request.body.bytes",
-		RequestBytesUnread: "http.request.body.unread.bytes",
-		RequestUserAgent:   "user_agent.original",
-		RequestReferer:     "http.request.referrer",
-		ResponseHeaders:    "http.response.headers",
-		ResponseBody:       "http.response.body.content",
-		ResponseStatus:     "http.response.status_code",
-		ResponseDuration:   ECSResponseDuration,
-		ResponseBytes:      "http.response.body.bytes",
+		Timestamp:          "@timestamp",                     // https://www.elastic.co/docs/reference/ecs/ecs-base#field-timestamp
+		Level:              "log.level",                      // https://www.elastic.co/docs/reference/ecs/ecs-log#field-log-level
+		Message:            "message",                        // https://www.elastic.co/docs/reference/ecs/ecs-base#field-message
+		ErrorMessage:       "error.message",                  // https://www.elastic.co/docs/reference/ecs/ecs-error#field-error-message
+		ErrorType:          "error.type",                     // https://www.elastic.co/docs/reference/ecs/ecs-error#field-error-type
+		ErrorStackTrace:    "error.stack_trace",              // https://www.elastic.co/docs/reference/ecs/ecs-error#field-error-stack-trace
+		SourceFile:         "log.origin.file.name",           // https://www.elastic.co/docs/reference/ecs/ecs-log#field-log-origin-file-name
+		SourceLine:         "log.origin.file.line",           // https://www.elastic.co/docs/reference/ecs/ecs-log#field-log-origin-file-line
+		SourceFunction:     "log.origin.function",            // https://www.elastic.co/docs/reference/ecs/ecs-log#field-log-origin-function
+		RequestURL:         "url.full",                       // https://www.elastic.co/docs/reference/ecs/ecs-url#field-url-full
+		RequestMethod:      "http.request.method",            // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-request-method
+		RequestPath:        "url.path",                       // https://www.elastic.co/docs/reference/ecs/ecs-url#field-url-path
+		RequestRemoteIP:    "client.ip",                      // https://www.elastic.co/docs/reference/ecs/ecs-client#field-client-ip
+		RequestHost:        "url.domain",                     // https://www.elastic.co/docs/reference/ecs/ecs-url#field-url-domain
+		RequestScheme:      "url.scheme",                     // https://www.elastic.co/docs/reference/ecs/ecs-url#field-url-scheme
+		RequestProto:       "http.version",                   // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-version
+		RequestHeaders:     "http.request.headers",           // Custom field; ECS 9.0.0 defines no header fields.
+		RequestBody:        "http.request.body.content",      // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-request-body-content
+		RequestBytes:       "http.request.body.bytes",        // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-request-body-bytes
+		RequestBytesUnread: "http.request.body.unread.bytes", // Custom field; not part of ECS 9.0.0.
+		RequestUserAgent:   "user_agent.original",            // https://www.elastic.co/docs/reference/ecs/ecs-user_agent#field-user-agent-original
+		RequestReferer:     "http.request.referrer",          // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-request-referrer
+		ResponseHeaders:    "http.response.headers",          // Custom field; ECS 9.0.0 defines no header fields.
+		ResponseBody:       "http.response.body.content",     // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-response-body-content
+		ResponseStatus:     "http.response.status_code",      // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-response-status-code
+		ResponseDuration:   ECSResponseDuration,              // https://www.elastic.co/docs/reference/ecs/ecs-event#field-event-duration
+		ResponseBytes:      "http.response.body.bytes",       // https://www.elastic.co/docs/reference/ecs/ecs-http#field-http-response-body-bytes
 	}
 
 	// SchemaOTEL represents OpenTelemetry (OTEL) semantic conventions version 1.34.0.
 	// This schema follows OpenTelemetry standards for observability data.
 	//
-	// Reference: https://opentelemetry.io/docs/specs/semconv/http/http-metrics
+	// References:
+	//   - https://github.com/open-telemetry/semantic-conventions/tree/v1.34.0/docs/registry/attributes
+	//   - https://opentelemetry.io/docs/specs/otel/logs/data-model/ (timestamp, severity_text, body)
 	SchemaOTEL = &Schema{
-		Timestamp:          "timestamp",
-		Level:              "severity_text",
-		Message:            "body",
-		ErrorMessage:       "error.message",
-		ErrorType:          "error.type",
-		ErrorStackTrace:    "exception.stacktrace",
-		SourceFile:         "code.file.path",
-		SourceLine:         "code.line.number",
-		SourceFunction:     "code.function.name",
-		RequestURL:         "url.full",
-		RequestMethod:      "http.request.method",
-		RequestPath:        "url.path",
-		RequestRemoteIP:    "client.address",
-		RequestHost:        "server.address",
-		RequestScheme:      "url.scheme",
-		RequestProto:       "network.protocol.version",
-		RequestHeaders:     "http.request.header",
-		RequestBody:        "http.request.body.content",
-		RequestBytes:       "http.request.body.size",
-		RequestBytesUnread: "http.request.body.unread.size",
-		RequestUserAgent:   "user_agent.original",
-		RequestReferer:     "http.request.header.referer",
-		ResponseHeaders:    "http.response.header",
-		ResponseBody:       "http.response.body.content",
-		ResponseStatus:     "http.response.status_code",
-		ResponseDuration:   OTELResponseDuration,
-		ResponseBytes:      "http.response.body.size",
+		Timestamp:          "timestamp",                     // Log record field: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-timestamp
+		Level:              "severity_text",                 // Log record field: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitytext
+		Message:            "body",                          // Log record field: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body
+		ErrorMessage:       "error.message",                 // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/error.md
+		ErrorType:          "error.type",                    // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/error.md
+		ErrorStackTrace:    "exception.stacktrace",          // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/exception.md
+		SourceFile:         "code.file.path",                // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md
+		SourceLine:         "code.line.number",              // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md
+		SourceFunction:     "code.function.name",            // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md
+		RequestURL:         "url.full",                      // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/url.md
+		RequestMethod:      "http.request.method",           // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		RequestPath:        "url.path",                      // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/url.md
+		RequestRemoteIP:    "client.address",                // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/client.md
+		RequestHost:        "server.address",                // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/server.md
+		RequestScheme:      "url.scheme",                    // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/url.md
+		RequestProto:       "network.protocol.version",      // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/network.md
+		RequestHeaders:     "http.request.header",           // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		RequestBody:        "http.request.body.content",     // Custom field (ECS name); OTEL semconv defines no body content attribute.
+		RequestBytes:       "http.request.body.size",        // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		RequestBytesUnread: "http.request.body.unread.size", // Custom field; not part of OTEL semconv.
+		RequestUserAgent:   "user_agent.original",           // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/user-agent.md
+		RequestReferer:     "http.request.header.referer",   // Templated header attribute: https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		ResponseHeaders:    "http.response.header",          // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		ResponseBody:       "http.response.body.content",    // Custom field (ECS name); OTEL semconv defines no body content attribute.
+		ResponseStatus:     "http.response.status_code",     // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
+		ResponseDuration:   OTELResponseDuration,            // Metric name reused as a log attribute: https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/http/http-metrics.md#metric-httpserverrequestduration
+		ResponseBytes:      "http.response.body.size",       // https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/http.md
 	}
 
 	// SchemaGCP represents Google Cloud Platform's structured logging format.
 	// This schema is optimized for Google Cloud Logging service.
 	//
 	// References:
-	//   - https://cloud.google.com/logging/docs/structured-logging
+	//   - https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
 	//   - https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+	//   - https://cloud.google.com/error-reporting/docs/formatting-error-messages
+	//
 	// Fields not defined by LogEntry#HttpRequest live at the top level of jsonPayload:
 	// the Logging API rejects the whole entry on unknown httpRequest subfields.
 	SchemaGCP = &Schema{
-		Timestamp:          "time",
-		Level:              GCPLevel,
-		Message:            "message",
-		ErrorMessage:       "error",
-		ErrorType:          "error_type",
-		ErrorStackTrace:    "stack_trace",
-		SourceFile:         "logging.googleapis.com/sourceLocation:file",
-		SourceLine:         "logging.googleapis.com/sourceLocation:line",
-		SourceFunction:     "logging.googleapis.com/sourceLocation:function",
-		RequestURL:         "httpRequest:requestUrl",
-		RequestMethod:      "httpRequest:requestMethod",
-		RequestPath:        "requestPath",
-		RequestRemoteIP:    "httpRequest:remoteIp",
-		RequestHost:        "host",
-		RequestScheme:      "scheme",
-		RequestProto:       "httpRequest:protocol",
-		RequestHeaders:     "requestHeaders",
-		RequestBody:        "requestBody",
-		RequestBytes:       "httpRequest:requestSize",
-		RequestBytesUnread: "requestUnreadSize",
-		RequestUserAgent:   "httpRequest:userAgent",
-		RequestReferer:     "httpRequest:referer",
-		ResponseHeaders:    "responseHeaders",
-		ResponseBody:       "responseBody",
-		ResponseStatus:     "httpRequest:status",
-		ResponseDuration:   GCPResponseDuration,
-		ResponseBytes:      "httpRequest:responseSize",
+		Timestamp:          "time",                                           // https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+		Level:              GCPLevel,                                         // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+		Message:            "message",                                        // https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+		ErrorMessage:       "error",                                          // Custom jsonPayload field; Error Reporting reads stack_trace/message instead.
+		ErrorType:          "error_type",                                     // Custom jsonPayload field.
+		ErrorStackTrace:    "stack_trace",                                    // https://cloud.google.com/error-reporting/docs/formatting-error-messages
+		SourceFile:         "logging.googleapis.com/sourceLocation:file",     // https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+		SourceLine:         "logging.googleapis.com/sourceLocation:line",     // https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+		SourceFunction:     "logging.googleapis.com/sourceLocation:function", // https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+		RequestURL:         "httpRequest:requestUrl",                         // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestMethod:      "httpRequest:requestMethod",                      // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestPath:        "requestPath",                                    // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestRemoteIP:    "httpRequest:remoteIp",                           // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestHost:        "host",                                           // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestScheme:      "scheme",                                         // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestProto:       "httpRequest:protocol",                           // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestHeaders:     "requestHeaders",                                 // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestBody:        "requestBody",                                    // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestBytes:       "httpRequest:requestSize",                        // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestBytesUnread: "requestUnreadSize",                              // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		RequestUserAgent:   "httpRequest:userAgent",                          // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		RequestReferer:     "httpRequest:referer",                            // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		ResponseHeaders:    "responseHeaders",                                // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		ResponseBody:       "responseBody",                                   // Custom jsonPayload field; not part of LogEntry#HttpRequest.
+		ResponseStatus:     "httpRequest:status",                             // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		ResponseDuration:   GCPResponseDuration,                              // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest.FIELDS.latency
+		ResponseBytes:      "httpRequest:responseSize",                       // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
 		GroupDelimiter:     ":",
 	}
 )

--- a/schema.go
+++ b/schema.go
@@ -10,6 +10,8 @@ const (
 	ECSResponseDuration  = "event.duration"
 	OTELResponseDuration = "http.server.request.duration"
 	GCPResponseDuration  = "httpRequest:latency"
+
+	GCPLevel = "severity"
 )
 
 // Schema defines the mapping of semantic log fields to their corresponding
@@ -105,9 +107,9 @@ var (
 		ErrorMessage:       "error.message",
 		ErrorType:          "error.type",
 		ErrorStackTrace:    "exception.stacktrace",
-		SourceFile:         "code.filepath",
-		SourceLine:         "code.lineno",
-		SourceFunction:     "code.function",
+		SourceFile:         "code.file.path",
+		SourceLine:         "code.line.number",
+		SourceFunction:     "code.function.name",
 		RequestURL:         "url.full",
 		RequestMethod:      "http.request.method",
 		RequestPath:        "url.path",
@@ -134,9 +136,11 @@ var (
 	// References:
 	//   - https://cloud.google.com/logging/docs/structured-logging
 	//   - https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+	// Fields not defined by LogEntry#HttpRequest live at the top level of jsonPayload:
+	// the Logging API rejects the whole entry on unknown httpRequest subfields.
 	SchemaGCP = &Schema{
-		Timestamp:          "timestamp",
-		Level:              "severity",
+		Timestamp:          "time",
+		Level:              GCPLevel,
 		Message:            "message",
 		ErrorMessage:       "error",
 		ErrorType:          "error_type",
@@ -146,19 +150,19 @@ var (
 		SourceFunction:     "logging.googleapis.com/sourceLocation:function",
 		RequestURL:         "httpRequest:requestUrl",
 		RequestMethod:      "httpRequest:requestMethod",
-		RequestPath:        "httpRequest:requestPath",
+		RequestPath:        "requestPath",
 		RequestRemoteIP:    "httpRequest:remoteIp",
-		RequestHost:        "httpRequest:host",
-		RequestScheme:      "httpRequest:scheme",
+		RequestHost:        "host",
+		RequestScheme:      "scheme",
 		RequestProto:       "httpRequest:protocol",
-		RequestHeaders:     "httpRequest:requestHeaders",
-		RequestBody:        "httpRequest:requestBody",
+		RequestHeaders:     "requestHeaders",
+		RequestBody:        "requestBody",
 		RequestBytes:       "httpRequest:requestSize",
-		RequestBytesUnread: "httpRequest:requestUnreadSize",
+		RequestBytesUnread: "requestUnreadSize",
 		RequestUserAgent:   "httpRequest:userAgent",
 		RequestReferer:     "httpRequest:referer",
-		ResponseHeaders:    "httpRequest:responseHeaders",
-		ResponseBody:       "httpRequest:responseBody",
+		ResponseHeaders:    "responseHeaders",
+		ResponseBody:       "responseBody",
 		ResponseStatus:     "httpRequest:status",
 		ResponseDuration:   GCPResponseDuration,
 		ResponseBytes:      "httpRequest:responseSize",
@@ -177,10 +181,15 @@ func (s *Schema) ReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 		if s.Timestamp == "" {
 			return a
 		}
-		return slog.String(s.Timestamp, a.Value.Time().Format(time.RFC3339))
+		return slog.String(s.Timestamp, a.Value.Time().Format(time.RFC3339Nano))
 	case slog.LevelKey:
 		if s.Level == "" {
 			return a
+		}
+		if s.Level == GCPLevel {
+			if lvl, ok := a.Value.Any().(slog.Level); ok {
+				return slog.String(s.Level, gcpLogSeverity(lvl))
+			}
 		}
 		return slog.String(s.Level, a.Value.String())
 	case slog.MessageKey:
@@ -225,6 +234,22 @@ func (s *Schema) ReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 	}
 
 	return a
+}
+
+// gcpLogSeverity maps slog levels to GCP LogSeverity values, which have no "WARN".
+//
+// Reference: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+func gcpLogSeverity(level slog.Level) string {
+	switch {
+	case level < slog.LevelInfo:
+		return "DEBUG"
+	case level < slog.LevelWarn:
+		return "INFO"
+	case level < slog.LevelError:
+		return "WARNING"
+	default:
+		return "ERROR"
+	}
 }
 
 // Concise returns a simplified schema with essential fields only.

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,250 @@
+package httplog
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func captureLog(t *testing.T, schema *Schema, method string, handler http.HandlerFunc) map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: schema.ReplaceAttr,
+	}))
+
+	mw := RequestLogger(logger, &Options{
+		Level:              slog.LevelDebug,
+		Schema:             schema,
+		RecoverPanics:      true,
+		LogRequestHeaders:  []string{"Content-Type"},
+		LogResponseHeaders: []string{"Content-Type"},
+	})
+
+	req := httptest.NewRequest(method, "/api/users", nil)
+	req.Host = "example.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "test-agent")
+	req.Header.Set("Referer", "https://example.com/home")
+
+	mw(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	if buf.Len() == 0 {
+		t.Fatal("no log entry emitted")
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON log entry: %v\n%s", err, buf.String())
+	}
+	return entry
+}
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write([]byte(`{}`))
+}
+
+func statusHandler(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}
+}
+
+func TestSchemaECSFieldNames(t *testing.T) {
+	entry := captureLog(t, SchemaECS, "GET", okHandler)
+
+	for _, key := range []string{
+		"@timestamp", "log.level", "message",
+		"url.full", "http.request.method", "url.path", "client.ip", "url.domain",
+		"url.scheme", "http.version", "http.request.headers", "http.request.body.bytes",
+		"user_agent.original", "http.request.referrer",
+		"http.response.headers", "http.response.status_code", "event.duration", "http.response.body.bytes",
+	} {
+		if _, ok := entry[key]; !ok {
+			t.Errorf("missing ECS field %q in %v", key, entry)
+		}
+	}
+
+	if ts, _ := entry["@timestamp"].(string); ts == "" {
+		t.Errorf("@timestamp is not a string: %v", entry["@timestamp"])
+	} else if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+		t.Errorf("@timestamp is not RFC3339Nano: %v", err)
+	}
+
+	// ECS event.duration is nanoseconds as a JSON number.
+	if _, ok := entry["event.duration"].(float64); !ok {
+		t.Errorf("event.duration is not a number: %v", entry["event.duration"])
+	}
+}
+
+func TestSchemaOTELFieldNames(t *testing.T) {
+	entry := captureLog(t, SchemaOTEL, "GET", okHandler)
+
+	for _, key := range []string{
+		"timestamp", "severity_text", "body",
+		"url.full", "http.request.method", "url.path", "client.address", "server.address",
+		"url.scheme", "network.protocol.version", "http.request.header", "http.request.body.size",
+		"user_agent.original", "http.request.header.referer",
+		"http.response.header", "http.response.status_code", "http.server.request.duration", "http.response.body.size",
+	} {
+		if _, ok := entry[key]; !ok {
+			t.Errorf("missing OTEL field %q in %v", key, entry)
+		}
+	}
+}
+
+func TestSchemaOTELSourceLocation(t *testing.T) {
+	src := &slog.Source{File: "/app/main.go", Line: 42, Function: "main.main"}
+	a := SchemaOTEL.ReplaceAttr(nil, slog.Any(slog.SourceKey, src))
+
+	got := map[string]bool{}
+	for _, attr := range a.Value.Group() {
+		got[attr.Key] = true
+	}
+	// Semconv v1.31.0+ names; code.filepath, code.lineno and code.function are deprecated.
+	for _, key := range []string{"code.file.path", "code.line.number", "code.function.name"} {
+		if !got[key] {
+			t.Errorf("missing OTEL source attribute %q in %v", key, got)
+		}
+	}
+}
+
+func TestSchemaGCPFieldNames(t *testing.T) {
+	entry := captureLog(t, SchemaGCP, "GET", okHandler)
+
+	for _, key := range []string{
+		"time", "severity", "message", "httpRequest",
+		"requestPath", "host", "scheme", "requestHeaders", "responseHeaders",
+	} {
+		if _, ok := entry[key]; !ok {
+			t.Errorf("missing GCP field %q in %v", key, entry)
+		}
+	}
+
+	// Cloud Logging's "timestamp" special field must be an object; the string form is "time".
+	if _, ok := entry["timestamp"]; ok {
+		t.Errorf(`unexpected "timestamp" field: string timestamps belong in "time"`)
+	}
+	if ts, _ := entry["time"].(string); ts == "" {
+		t.Errorf("time is not a string: %v", entry["time"])
+	} else if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+		t.Errorf("time is not RFC3339Nano: %v", err)
+	}
+
+	// The Logging API rejects entries with unknown httpRequest subfields, so the
+	// nested object must stay within LogEntry#HttpRequest's official field set.
+	officialHTTPRequestFields := map[string]bool{
+		"requestMethod": true, "requestUrl": true, "requestSize": true, "status": true,
+		"responseSize": true, "userAgent": true, "remoteIp": true, "serverIp": true,
+		"referer": true, "latency": true, "cacheLookup": true, "cacheHit": true,
+		"cacheValidatedWithOriginServer": true, "cacheFillBytes": true, "protocol": true,
+	}
+	httpRequest, ok := entry["httpRequest"].(map[string]any)
+	if !ok {
+		t.Fatalf("httpRequest is not an object: %v", entry["httpRequest"])
+	}
+	for key := range httpRequest {
+		if !officialHTTPRequestFields[key] {
+			t.Errorf("unofficial field %q in httpRequest", key)
+		}
+	}
+	for _, key := range []string{
+		"requestUrl", "requestMethod", "remoteIp", "protocol", "requestSize",
+		"userAgent", "referer", "status", "latency", "responseSize",
+	} {
+		if _, ok := httpRequest[key]; !ok {
+			t.Errorf("missing httpRequest field %q in %v", key, httpRequest)
+		}
+	}
+
+	if latency, _ := httpRequest["latency"].(string); !regexp.MustCompile(`^\d+(\.\d+)?s$`).MatchString(latency) {
+		t.Errorf("latency %q does not match the GCP duration format", latency)
+	}
+}
+
+func TestSchemaGCPSourceLocation(t *testing.T) {
+	src := &slog.Source{File: "/app/main.go", Line: 42, Function: "main.main"}
+	a := SchemaGCP.ReplaceAttr(nil, slog.Any(slog.SourceKey, src))
+
+	if a.Key != "logging.googleapis.com/sourceLocation" {
+		t.Errorf("unexpected source location group %q", a.Key)
+	}
+	got := map[string]bool{}
+	for _, attr := range a.Value.Group() {
+		got[attr.Key] = true
+	}
+	for _, key := range []string{"file", "line", "function"} {
+		if !got[key] {
+			t.Errorf("missing sourceLocation attribute %q in %v", key, got)
+		}
+	}
+}
+
+func TestSchemaGCPSeverity(t *testing.T) {
+	tests := []struct {
+		method   string
+		handler  http.HandlerFunc
+		severity string
+	}{
+		{"GET", okHandler, "INFO"},
+		{"GET", statusHandler(400), "WARNING"},
+		{"GET", statusHandler(429), "INFO"},
+		{"GET", statusHandler(500), "ERROR"},
+		{"OPTIONS", okHandler, "DEBUG"},
+	}
+
+	for _, tt := range tests {
+		entry := captureLog(t, SchemaGCP, tt.method, tt.handler)
+		if entry["severity"] != tt.severity {
+			t.Errorf("%s %v: severity = %v, want %q", tt.method, tt.handler, entry["severity"], tt.severity)
+		}
+	}
+}
+
+func TestPanicStackTrace(t *testing.T) {
+	panicHandler := func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}
+
+	tests := []struct {
+		name          string
+		schema        *Schema
+		stackTraceKey string
+		errorKey      string
+	}{
+		{"ECS", SchemaECS, "error.stack_trace", "error.message"},
+		{"OTEL", SchemaOTEL, "exception.stacktrace", "error.message"},
+		{"GCP", SchemaGCP, "stack_trace", "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := captureLog(t, tt.schema, "GET", panicHandler)
+
+			if entry[tt.errorKey] != "panic: boom" {
+				t.Errorf("%s = %v, want %q", tt.errorKey, entry[tt.errorKey], "panic: boom")
+			}
+
+			// Go panic format: parseable by GCP Error Reporting, single string for ECS/OTEL.
+			stackTrace, ok := entry[tt.stackTraceKey].(string)
+			if !ok {
+				t.Fatalf("%s is not a string: %v", tt.stackTraceKey, entry[tt.stackTraceKey])
+			}
+			if !strings.HasPrefix(stackTrace, "panic: boom\n\ngoroutine ") {
+				t.Errorf("%s does not start with the Go panic format:\n%s", tt.stackTraceKey, stackTrace)
+			}
+			if !strings.Contains(stackTrace, "schema_test.go") {
+				t.Errorf("%s does not contain the panic origin:\n%s", tt.stackTraceKey, stackTrace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Verified all three schemas against their specs — ECS 9.0, OTEL semconv v1.34.0, GCP Cloud
Logging `LogEntry` — and fixed the field names and values that don't conform.

### Field name changes

| Schema | Field | Before | After | Reference |
|---|---|---|---|---|
| OTEL | `SourceFile` | `code.filepath` | `code.file.path` | [semconv v1.34.0 `code` registry](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md) |
| OTEL | `SourceLine` | `code.lineno` | `code.line.number` | [semconv v1.34.0 `code` registry](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md) |
| OTEL | `SourceFunction` | `code.function` | `code.function.name` | [semconv v1.34.0 `code` registry](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md) |
| GCP | `Timestamp` | `timestamp` | `time` | [Structured logging: special fields](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields) |
| GCP | `RequestPath` | `httpRequest.requestPath` | `requestPath` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `RequestHost` | `httpRequest.host` | `host` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `RequestScheme` | `httpRequest.scheme` | `scheme` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `RequestHeaders` | `httpRequest.requestHeaders` | `requestHeaders` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `RequestBody` | `httpRequest.requestBody` | `requestBody` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `RequestBytesUnread` | `httpRequest.requestUnreadSize` | `requestUnreadSize` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `ResponseHeaders` | `httpRequest.responseHeaders` | `responseHeaders` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |
| GCP | `ResponseBody` | `httpRequest.responseBody` | `responseBody` | [LogEntry v2 `HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) |

Why:
- OTEL `code.*` names were renamed in semconv [v1.31.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/code.md) — we pin v1.34.0 but shipped the deprecated names.
- Cloud Logging recognizes a string timestamp only under `time`; `timestamp` must be a `{seconds, nanos}` object. Our RFC3339 string under `timestamp` was ignored and ingestion time was used instead.
- The Logging API rejects the whole entry (HTTP 400) on unknown `httpRequest` subfields. Custom fields now live at the top level of `jsonPayload`; `httpRequest` carries only official [LogEntry#HttpRequest](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) fields. (Note: `httpRequest.host` was never a real field — the proto only has `serverIp`.)

### Value changes (same field names)

| Schema | Field | Before | After | Reference |
|---|---|---|---|---|
| GCP | `severity` | `WARN` — invalid LogSeverity | `WARNING` — slog levels mapped to LogSeverity | [LogEntry v2 `LogSeverity`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity) |
| all | stack trace | JSON array of `file:line` | Go panic-format string (`panic: ...\n\ngoroutine ...`) | [Error Reporting: formatting](https://cloud.google.com/error-reporting/docs/formatting-error-messages), [ECS 9.0 `error.stack_trace`](https://www.elastic.co/docs/reference/ecs/ecs-error), [semconv v1.34.0 `exception.stacktrace`](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/registry/attributes/exception.md) |
| all | timestamp | RFC3339 (whole seconds) | RFC3339Nano | [ECS 9.0 `@timestamp`](https://www.elastic.co/docs/reference/ecs/ecs-base) |

Why:
- LogSeverity has no `WARN`; stricter ingest paths degrade it to `DEFAULT`.
- [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages) only parses string stack traces in Go panic format, so panics never grouped as errors. ECS `error.stack_trace` and OTEL `exception.stacktrace` are string-typed too. No frame data is lost — `debug.Stack()` includes every `file:line` plus function names.
- RFC3339 truncated to whole seconds, losing sub-second ordering.

### Tests

New `schema_test.go` locks all of this in: end-to-end emitted field names per schema,
`httpRequest` staying within the official field set, LogSeverity mapping, latency format,
sourceLocation grouping, and the panic stack trace format.

🤖 This message was generated by Claude on behalf of Vojtech.
