### PR TITLE
fix: make empty Content-Type whitelist entry match only missing Content-Type

### DIFF
--- a/logbody_test.go
+++ b/logbody_test.go
@@ -1,0 +1,54 @@
+package httplog
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+func TestLogBodyContentTypes(t *testing.T) {
+	o := &Options{
+		LogBodyContentTypes: defaultOptions.LogBodyContentTypes,
+		LogBodyMaxLen:       defaultOptions.LogBodyMaxLen,
+	}
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		want        string
+	}{
+		{"json is logged", "application/json", `{"a":1}`, `{"a":1}`},
+		{"json with charset is logged", "application/json; charset=utf-8", `{"a":1}`, `{"a":1}`},
+		{"missing content type is logged", "", "hello", "hello"},
+		{"binary is redacted", "image/png", "\x89PNG", "[body redacted for Content-Type: image/png]"},
+		{"gzip is redacted", "application/gzip", "data", "[body redacted for Content-Type: application/gzip]"},
+		{"html is redacted", "text/html", "<html>", "[body redacted for Content-Type: text/html]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			if tt.contentType != "" {
+				header.Set("Content-Type", tt.contentType)
+			}
+			got := logBody(bytes.NewBufferString(tt.body), header, o)
+			if got != tt.want {
+				t.Errorf("logBody() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogBodyMaxLen(t *testing.T) {
+	o := &Options{
+		LogBodyContentTypes: []string{"text/plain"},
+		LogBodyMaxLen:       5,
+	}
+	header := http.Header{}
+	header.Set("Content-Type", "text/plain")
+
+	if got := logBody(bytes.NewBufferString("hello world"), header, o); got != "hello... [trimmed]" {
+		t.Errorf("logBody() = %q", got)
+	}
+}

--- a/middleware.go
+++ b/middleware.go
@@ -232,6 +232,11 @@ func logBody(body *bytes.Buffer, header http.Header, o *Options) string {
 	}
 	contentType := header.Get("Content-Type")
 	for _, whitelisted := range o.LogBodyContentTypes {
+		// An empty entry whitelists only requests with no Content-Type header;
+		// HasPrefix with "" would match everything and make redaction unreachable.
+		if whitelisted == "" && contentType != "" {
+			continue
+		}
 		if strings.HasPrefix(contentType, whitelisted) {
 			if o.LogBodyMaxLen <= 0 || o.LogBodyMaxLen >= body.Len() {
 				return body.String()


### PR DESCRIPTION
`strings.HasPrefix(contentType, "")` matches every content type. Since the default `LogBodyContentTypes` includes `""`, the whitelist passed everything and the `[body redacted for Content-Type: ...]` branch was unreachable — binary bodies (images, gzip, protobuf) were logged raw. An empty entry now matches only requests with no `Content-Type` header, which was its intent. Tests cover whitelisted types, missing Content-Type, redaction, and `LogBodyMaxLen` trimming.

🤖 This message was generated by Claude on behalf of Vojtech.
