### PR TITLE
fix: call LogResponseBody predicate once per request

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -49,7 +49,7 @@ func RequestLogger(logger *slog.Logger, o *Options) func(http.Handler) http.Hand
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 			var respBody bytes.Buffer
-			if o.LogResponseBody != nil && o.LogResponseBody(r) {
+			if logRespBody {
 				ww.Tee(&respBody)
 			}
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,38 @@
+package httplog
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBodyPredicatesCalledOnce(t *testing.T) {
+	var reqCalls, respCalls int
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	mw := RequestLogger(logger, &Options{
+		Schema:          SchemaECS,
+		LogRequestBody:  func(*http.Request) bool { reqCalls++; return true },
+		LogResponseBody: func(*http.Request) bool { respCalls++; return true },
+	})
+
+	req := httptest.NewRequest("POST", "/api/users", strings.NewReader(`{"a":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	mw(http.HandlerFunc(okHandler)).ServeHTTP(httptest.NewRecorder(), req)
+
+	if reqCalls != 1 {
+		t.Errorf("LogRequestBody called %d times, want 1", reqCalls)
+	}
+	if respCalls != 1 {
+		t.Errorf("LogResponseBody called %d times, want 1", respCalls)
+	}
+
+	// The predicate's single result must still drive the response body capture.
+	if !strings.Contains(buf.String(), `"http.response.body.content":"{}"`) {
+		t.Errorf("response body not logged: %s", buf.String())
+	}
+}


### PR DESCRIPTION
The predicate result was already stored in `logRespBody`, but the `ww.Tee()` decision invoked it a second time. A stateful or non-deterministic predicate could make the capture and the final logging disagree. The Tee decision now reuses `logRespBody`. Test asserts both body predicates run exactly once per request and the response body still gets logged.

🤖 This message was generated by Claude on behalf of Vojtech.
