### PR TITLE
ci: add GitHub Actions workflow (gofmt, build, vet, test -race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt
+        run: test -z "$(gofmt -l .)" || (gofmt -l . && exit 1)
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...


### PR DESCRIPTION
First CI for this repo: runs gofmt check, `go build`, `go vet`, and `go test -race` on every PR and push to master. Go version comes from `go.mod` via `setup-go`, so bumps stay in one place.

🤖 This message was generated by Claude on behalf of Vojtech.
