### PR TITLE
fix: don't duplicate scheme and host for absolute request URLs

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -42,5 +42,10 @@ func scheme(r *http.Request) string {
 }
 
 func requestURL(r *http.Request) string {
+	// r.URL is absolute for proxy absolute-form requests (RFC 9112, section 3.2.2);
+	// prepending scheme and host again would duplicate them.
+	if r.URL.IsAbs() {
+		return r.URL.String()
+	}
 	return fmt.Sprintf("%s://%s%s", scheme(r), r.Host, r.URL)
 }

--- a/requesturl_test.go
+++ b/requesturl_test.go
@@ -1,0 +1,21 @@
+package httplog
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestURL(t *testing.T) {
+	// httptest.NewRequest with an absolute target keeps r.URL absolute,
+	// mimicking proxy absolute-form requests. See issue #72.
+	abs := httptest.NewRequest("GET", "http://localhost:8080/api/users?q=1", nil)
+	if got, want := requestURL(abs), "http://localhost:8080/api/users?q=1"; got != want {
+		t.Errorf("requestURL() = %q, want %q", got, want)
+	}
+
+	rel := httptest.NewRequest("GET", "/api/users", nil)
+	rel.Host = "example.com"
+	if got, want := requestURL(rel), "http://example.com/api/users"; got != want {
+		t.Errorf("requestURL() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #72. `requestURL` prepended `scheme://r.Host` to `r.URL` unconditionally; when `r.URL` is absolute (proxy absolute-form requests, `httptest.NewRequest` with a full URL), the host doubled: `http://localhost:8080http://localhost:8080/api/users`. Absolute URLs are now returned as-is. Out of scope, noted for later: `scheme()` ignores `X-Forwarded-Proto` behind TLS-terminating proxies.

🤖 This message was generated by Claude on behalf of Vojtech.
